### PR TITLE
#3 filename with headers and more.

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,14 @@
+export interface JFMCCacheContent {
+  request: {
+    url: string;
+    headers?: Record<string, string | string[]>;
+  };
+  response: {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    headers: Record<string, string | string[]>;
+    bodyJson?: string;
+    bodyText?: string;
+  };
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,7 +3,7 @@ fetchMock.enableMocks();
 
 import { describe, expect, test as it } from "@jest/globals";
 
-import createCachingMock from "./index";
+import { createCachingMock } from "./index";
 // import JFMCNodeFSStore from "./stores/nodeFs";
 import JSMCMemoryStore from "./stores/memory";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,14 @@
 import fetchMock from "jest-fetch-mock";
 import _debug from "debug";
-
-import JFMCStore from "./store";
+import type { JFMCCacheContent } from "./cache";
 import { serializeHeaders, unserializeHeaders } from "./headers";
+import JFMCNodeFSStore from "./stores/nodeFs";
+export { JFMCNodeFSStore as NodeFSStore };
+import JFMCStore from "./store";
 
 const debug = _debug("jest-fetch-mock-cache:core");
 
-export interface JFMCCacheContent {
-  request: {
-    url: string;
-    headers?: Record<string, string | string[]>;
-  };
-  response: {
-    ok: boolean;
-    status: number;
-    statusText: string;
-    headers: Record<string, string | string[]>;
-    bodyJson?: string;
-    bodyText?: string;
-  };
-}
-
-export default function createCachingMock({
-  store,
-}: { store?: JFMCStore } = {}) {
+export function createCachingMock({ store }: { store?: JFMCStore } = {}) {
   if (!store)
     throw new Error(
       "No `store` option was provided, but is required.  See docs.",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import type { JFMCCacheContent } from "./index";
+import type { JFMCCacheContent } from "./cache";
 
 const localCrypto =
   typeof crypto === "undefined" ? require("node:crypto").webcrypto : crypto;

--- a/src/stores/memory.spec.ts
+++ b/src/stores/memory.spec.ts
@@ -3,7 +3,7 @@ fetchMock.enableMocks();
 
 import { describe, expect, test as it } from "@jest/globals";
 
-import createCachingMock from "../index";
+import { createCachingMock } from "../index";
 import JSMCMemoryStore from "./memory";
 import { createTestsForMock } from "../testUtils";
 

--- a/src/stores/nodeFs.spec.ts
+++ b/src/stores/nodeFs.spec.ts
@@ -4,7 +4,7 @@ fetchMock.enableMocks();
 import fs from "fs/promises";
 import { describe, expect, test as it } from "@jest/globals";
 
-import createCachingMock from "../index";
+import { createCachingMock } from "../index";
 import nodeFsStore from "./nodeFs";
 import { createTestsForMock } from "../testUtils";
 

--- a/src/stores/nodeFs.ts
+++ b/src/stores/nodeFs.ts
@@ -21,7 +21,7 @@ class JFMCNodeFSStore extends JFMCStore {
     let filename = filenamifyUrl(request.url);
     if (Array.from(request.headers.keys()).length > 0) {
       const headersHash = await this.hashFromHeaders(request.headers, 7);
-      filename += `[headers:${headersHash}]`;
+      filename += `[headers=${headersHash}]`;
     }
     return filename + ".json";
   }

--- a/src/stores/nodeFs.ts
+++ b/src/stores/nodeFs.ts
@@ -1,5 +1,6 @@
 import filenamifyUrl from "filenamify-url";
 import fs from "fs/promises";
+import path from "path";
 
 import JFMCStore from "../store";
 import type { JFMCCacheContent } from "../store";
@@ -7,14 +8,20 @@ import type { JFMCCacheContent } from "../store";
 class JFMCNodeFSStore extends JFMCStore {
   _createdCacheDir = false;
   _cwd = process.cwd();
+  _location: string;
 
+  constructor(location?: string) {
+    super();
+    this._location = location || "__cache__";
+  }
+
+  // Cache in a sub-folder in the tests folder.
   async cache_dir(filename: string) {
     if (!this._createdCacheDir) {
       this._createdCacheDir = true;
       await fs.mkdir(await this.cache_dir(""), { recursive: true });
     }
-
-    return `${this._cwd}/tests/fixtures/http/${filename}`;
+    return path.join(this._cwd, "tests", this._location, filename);
   }
 
   async idFromResponse(request: Request): Promise<string> {

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,4 +1,4 @@
-import createCachingMock from "./index";
+import { createCachingMock } from "./index";
 
 export function createTestsForMock(mock: ReturnType<typeof createCachingMock>) {
   it("works with a Request as first argument", async () => {


### PR DESCRIPTION
Fixed initial usage issues:
- filename with header and hash was invalid.
- proposal to use `__cache__` following jest naming.
- NodeJSStore not exported.
- possible circular dependency JFMCCacheContent.
- ts-jest complains about createCachingMock not a function (changed to named export).